### PR TITLE
AbuBot SQLite execute sanitization

### DIFF
--- a/AbuBot/course_cmds.py
+++ b/AbuBot/course_cmds.py
@@ -10,7 +10,7 @@ class GetCourses(commands.Cog):
 
      @commands.command()
      async def course(self, ctx, dept, code):
-          course_data = course_finder.find_course(dept+" "+code)
+          course_data = course_finder.find_course(dept, code)
           if course_data == "Error":
                await ctx.send(f"Failed to retrieve course data for {str(dept+' '+code).upper()}")
           else:

--- a/AbuBot/course_finder.py
+++ b/AbuBot/course_finder.py
@@ -13,7 +13,7 @@ class Course():
         try:
             cur = conn.cursor()
             course_dept = course_dept.upper().replace("'", '')
-            course_code = course_dept.upper().replace("'", '')
+            course_code = course_code.upper().replace("'", '')
             cur.execute(f"SELECT * FROM '{course_dept}' WHERE ID = '{course_code}'")
             course = cur.fetchone()
             if course == None:

--- a/AbuBot/course_finder.py
+++ b/AbuBot/course_finder.py
@@ -8,12 +8,13 @@ warnings.filterwarnings('ignore')
 db_file = "AbuBot/courses.db"
 
 class Course():
-    def find_course(self,course_code):
+    def find_course(self, course_dept, course_code):
         conn = sqlite3.connect(db_file)
-        dept, code = course_code.split()
         try:
             cur = conn.cursor()
-            cur.execute(f"SELECT * FROM {dept.upper()} WHERE ID = '{code.upper()}'")
+            course_dept = course_dept.upper().replace("'", '')
+            course_code = course_dept.upper().replace("'", '')
+            cur.execute(f"SELECT * FROM '{course_dept}' WHERE ID = '{course_code}'")
             course = cur.fetchone()
             if course == None:
                 return "Error"


### PR DESCRIPTION
'potentially' fix injection bug. In this commit I change the function signature and partially sanitize input strings. More checking could be done such as checking for only a single whitespace separated word.


Something like the following would not throw an error and result in undefined behaviour

`f"SELECT * FROM {'ENGINEER WHERE ID=?; SELECT SQLITE_VERSION(); SELECT * FROM ENGINEER'} WHERE ID = '{'2PX3'}'"`

or even something more malicious, such as..

`f"SELECT * FROM {'ENGINEER WHERE ID=?; DROP TABLE COMPSCI; SELECT * FROM ENGINEER'} WHERE ID = '{'2PX3'}'"`

I realize that it's not really feasible to inject anything because the parameters are received as two space separated strings as allowed by the discord command, but the underlying class is flawed in this way