### PR TITLE
add prefixed_cog class decorator

### DIFF
--- a/AbuBot/course_cmds.py
+++ b/AbuBot/course_cmds.py
@@ -1,9 +1,11 @@
 import discord
 from AbuBot.course_module import Course
 from discord.ext import commands
+from addons.prefixed_cog import prefixed_cog
 
 course_mod = Course()
 
+@prefixed_cog
 class GetCourses(commands.Cog):
      def __init__(self, bot):
           self.bot = bot

--- a/Miscellaneous/emoji.py
+++ b/Miscellaneous/emoji.py
@@ -3,11 +3,13 @@ import requests
 import io
 import re
 from discord.ext import commands
+from addons.prefixed_cog import prefixed_cog
 
 '''
 Forked from https://github.com/appu1232/Discord-Selfbot/blob/master/cogs/emoji.py
 '''
 
+@prefixed_cog
 class Emoji(commands.Cog):
 
     def __init__(self, bot) -> None:

--- a/VerifyMe/verify_me.py
+++ b/VerifyMe/verify_me.py
@@ -1,6 +1,5 @@
 import discord
 import asyncio
-import json
 import os
 import os.path
 import smtplib
@@ -11,8 +10,10 @@ from email.message import EmailMessage
 from VerifyMe.database import Database
 
 from discord.ext import commands
+from addons.prefixed_cog import prefixed_cog
 
 
+@prefixed_cog
 class VerifyMe(commands.Cog):
 
     def __init__(self, bot, verify_message_id, verified_role_id, email_address, email_pass, server_id) -> None:

--- a/addons/prefixed_cog.py
+++ b/addons/prefixed_cog.py
@@ -1,0 +1,41 @@
+import yaml
+from discord.ext.commands.cog import CogMeta
+
+# TODO: config.yaml file should not need to be opened here.
+# default_prefix should be passed in through main, or something
+# like a global 'config_reader' singleton could solve this
+with open("config.yaml") as file:
+    config = yaml.load(file, Loader=yaml.FullLoader)
+available_prefixes = config["bot_prefixes"]
+default_prefix = available_prefixes[0]
+
+
+def prefixed_cog(cls : CogMeta) -> CogMeta:
+    '''
+    Decorates a class extending `discord.ext.commands.Cog` and overrides
+    the default cog_check coroutine. This effectively allows for the bot
+    to have multiple prefixes, with each cog listening for only it's own
+    respective prefix. If no prefix is specified in the constructor then
+    the first prefix in the list of prefixes is used (as declared above).
+
+    :example:
+    >>> @prefixed_cog
+    ... class MyCog(commands.Cog):
+    ...     def __init__(self, bot)
+    ...         self.bot = bot
+    ... 
+    >>> MyCog(bot=bot, prefix=".")
+    
+    '''
+
+    class PrefixedCog(cls):
+        def __init__(self, prefix = default_prefix, *args, **kwargs):
+            if prefix not in available_prefixes:
+                raise ValueError("The specified prefix is not a allowed in config.bot_prefixes.")
+            super(PrefixedCog, self).__init__(*args, **kwargs)
+            self.prefix = prefix
+
+        async def cog_check(self, ctx):
+            return ctx.prefix == self.prefix
+
+    return PrefixedCog

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-bot_prefix: "~"
+bot_prefixes: ["~", "."]
 admin: 209143819147542529
 create_channel_id: 811331713413414942 # ID of the "Create a VC!" channel
 ignore_pin_channels:

--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ else:
         config = yaml.load(file, Loader=yaml.FullLoader)
 
 intents = discord.Intents().all()
-bot = Bot(command_prefix=config["bot_prefix"], intent=intents)
+bot = Bot(command_prefix=config["bot_prefixes"], intent=intents)
 
 
 @bot.event
@@ -67,7 +67,7 @@ async def on_message(message):
 load_dotenv()
 
 bot.add_cog(TempVoice(bot=bot, vc_channel=config["create_channel_id"]))
-bot.add_cog(GetCourses(bot=bot))
+bot.add_cog(GetCourses(bot=bot, prefix="."))
 bot.add_cog(PinMe(bot=bot, ignore_channels=config["ignore_pin_channels"],
                   admin_channel_id=config["admin_channel_id"], server_id=config["server_id"], verified_role_id=config["verified_role_id"]))
 bot.add_cog(VerifyMe(bot=bot, verify_message_id=config["verify_message_id"], verified_role_id=config["verified_role_id"], email_address=os.getenv('EMAIL_USER'), email_pass=os.getenv('EMAIL_PASS'), server_id=config["server_id"]))


### PR DESCRIPTION
Created a class decorator function called `prefixed_cog` which wraps the decorated `Cog` and overrides the `cog_check` coroutine. If no cog is specified in the constructor then the first prefix in config.yaml is used.